### PR TITLE
Adding 'contributinginstitutionid' to the AssetData object response

### DIFF
--- a/src/lib/src/asset.interface.ts
+++ b/src/lib/src/asset.interface.ts
@@ -17,6 +17,7 @@ export class Asset {
     downloadName: string
     tileSource: string
     collectionType: number
+    contributinginstitutionid: number
     // Not reliably available
     categoryId: string
     categoryName: string
@@ -150,6 +151,7 @@ export class Asset {
         this.collectionName = data.collection_name
         this.filePropertiesArray = data.fileProperties
         this.collectionType = data.collection_type
+        this.contributinginstitutionid = data.contributinginstitutionid
         // we control the default size of the thumbnail url
         this.thumbnail_url = this.replaceThumbnailSize(data.thumbnail_url, this.thumbnail_size)
         this.typeId = data.object_type_id

--- a/src/lib/src/asset.service.ts
+++ b/src/lib/src/asset.service.ts
@@ -138,6 +138,7 @@ export class AssetService {
             collection_id: data.collection_id,
             collection_name: data.collection_name,
             collection_type: data.collection_type,
+            contributinginstitutionid: data.contributinginstitutionid,
             download_size: data.downloadSize || data.download_size || '1024,1024',
             fileProperties: data.fileProperties || [],
             height: data.height,
@@ -191,6 +192,7 @@ export interface AssetData {
   collection_id: string
   collection_name: string
   collection_type: number
+  contributinginstitutionid: number
   download_size: string
   fileProperties: FileProperty[] // array of objects with a key/value pair
   height: number
@@ -204,6 +206,7 @@ export interface AssetData {
   tileSourceHostname: string
   title: string
   updated_on: string
+
   viewer_data?: {
       base_asset_url?: string,
       panorama_xml?: string
@@ -220,6 +223,7 @@ interface AssetDataResponse {
   collection_id: string
   collection_name: string
   collection_type: number
+  contributinginstitutionid: number
   downloadSize?: string
   download_size?: string
   fileProperties: { [key: string]: string }[] // array of objects with a key/value pair


### PR DESCRIPTION
We need the 'contributinginstitutionid' info as part of the asset response object from the artstor-viewer component.